### PR TITLE
Remove stray hard breaks in the formal grammar

### DIFF
--- a/TSPL.docc/ReferenceManual/Declarations.md
+++ b/TSPL.docc/ReferenceManual/Declarations.md
@@ -33,7 +33,7 @@ the term *declaration* covers both declarations and definitions.
 > *declaration* → *subscript-declaration* \
 > *declaration* → *macro-declaration* \
 > *declaration* → *operator-declaration* \
-> *declaration* → *precedence-group-declaration* \
+> *declaration* → *precedence-group-declaration*
 
 ## Top-Level Code
 

--- a/TSPL.docc/ReferenceManual/Expressions.md
+++ b/TSPL.docc/ReferenceManual/Expressions.md
@@ -20,7 +20,7 @@ in the sections below.
 
 > Grammar of an expression:
 >
-> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_ \
+> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
 
 ## Prefix Expressions
 

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -748,7 +748,7 @@ make the same change here also.
 > *declaration* → *extension-declaration* \
 > *declaration* → *subscript-declaration* \
 > *declaration* → *operator-declaration* \
-> *declaration* → *precedence-group-declaration* \
+> *declaration* → *precedence-group-declaration*
 
 > Grammar of a top-level declaration:
 >

--- a/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
+++ b/TSPL.docc/ReferenceManual/SummaryOfTheGrammar.md
@@ -315,7 +315,7 @@ make the same change here also.
 
 > Grammar of an expression:
 >
-> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_ \
+> *expression* → *try-operator*_?_ *await-operator*_?_ *prefix-expression* *infix-expressions*_?_
 
 > Grammar of a prefix expression:
 >


### PR DESCRIPTION
Because this is the only line in the grammar box, there's no need to write a hard break after the production.  Including the backslash (\) like this produces an actual backslash in the rendered output.

Commit 8e713ce5c925178113e6949546d13321b865bf6f added hard breaks throughout the grammar, for readability, omitting a hard break for the last line and before blank lines.  However, in a few places we've edited the grammar since then but left behind stray backslashes.

Confirmed that these are the only two places where this happened by looking at the rendered summary of the grammar and searching for backslashes.

As discussed here: https://forums.swift.org/t/74659